### PR TITLE
Update SurveyReport to handle multiple answers for q19

### DIFF
--- a/admin/src/views/reports/SurveyReport.tsx
+++ b/admin/src/views/reports/SurveyReport.tsx
@@ -1046,12 +1046,11 @@ const viz = {
     },
     {
       key: 'Assets that exist within community',
-      qKeys: ['SMMEQuestionNineteen'],
+      qKeys: ['communityQuestionNineteen'],
       mutatorFn: (responses: any[], qKeys: string[], key: string) => {
         const filtered = responses.filter(
           (x) => x['questionSeven'] === 'No' && x[qKeys[0]]
         );
-
         const set = new Set();
         filtered.forEach((res) => {
           const item = res[qKeys[0]];
@@ -1071,7 +1070,12 @@ const viz = {
         labels.forEach((label) => {
           let count = 0;
           filtered.forEach((res) => {
-            res[qKeys[0]] === label && count++;
+            if (res && Array.isArray(res[qKeys[0]])) {
+              // @ts-ignore
+              res[qKeys[0]].includes(label) && count++;
+            } else {
+              res[qKeys[0]] === label && count++;
+            }
           });
           datasets[0].data.push(count);
         });


### PR DESCRIPTION
# Description
There was a bug in package 3.2 visualisation 8, where the bar graph was empty. This occurred because the visualisation filtered out responses from SMMEs, but then attempted to access the wrong question, 'SMMEQuestionNineteen', which had been filtered out. The correct question was 'communityQuestionNineteen', which is a community question. I have corrected the error and the visualisation is now functioning properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

 
