### PR TITLE
I20 358 satcap excel downloads are broken

### DIFF
--- a/admin/src/hooks/network/useLinks.ts
+++ b/admin/src/hooks/network/useLinks.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import {
   collection,
   DocumentData,
-  getCountFromServer,
   getDocs,
   orderBy,
   query,
@@ -13,13 +12,23 @@ import { ILink } from '../../types';
 
 export async function fetchLinkResponses(id: string) {
   const responses: DocumentData[] = [];
-  const resSnap = await getCountFromServer(
+  const resSnap = await getDocs(
     collection(
       db,
       `mines/${window.localStorage.getItem('mineId')}/links/${id}/responses`
     )
   );
-  return resSnap.data().count;
+  resSnap.forEach((doc) => {
+    const items = doc.data();
+    delete items?.consent;
+    delete items?.linkDocId;
+    delete items?.linkId;
+    delete items?.mineDocId;
+    delete items?.survey;
+
+    responses.push(items);
+  });
+  return responses;
 }
 
 export async function fetchLinks(force: boolean) {

--- a/admin/src/router.tsx
+++ b/admin/src/router.tsx
@@ -30,6 +30,7 @@ import { fetchSingleLink } from './hooks/network/useLink';
 import { Dashboard } from './views/dashboard/Dashboard';
 import { Summary } from './views/dashboard/Summary';
 import { useGetResponses } from './hooks/network/useResponses';
+import { Center, Loader, Stack } from '@mantine/core';
 
 export type LocationGenerics = MakeGenerics<{
   Params: {
@@ -146,6 +147,19 @@ export const routerFactory = (queryClient: any) => {
         {
           path: '/',
           element: <SurveyReports />,
+          pendingElement: async () => (
+            <Center>
+              <Stack align={'center'}>
+                <p>
+                  Surveys are being gathered, getting responses ready for you...
+                  Hold on tight!
+                </p>
+                <Loader />
+              </Stack>
+            </Center>
+          ),
+          pendingMs: 1000 * 2,
+          pendingMinMs: 500,
           loader: () =>
             queryClient.getQueryData(['linksResponses']) ??
             queryClient.fetchQuery(['linksResponses'], () => fetchLinks(true)),

--- a/admin/src/router.tsx
+++ b/admin/src/router.tsx
@@ -30,7 +30,6 @@ import { fetchSingleLink } from './hooks/network/useLink';
 import { Dashboard } from './views/dashboard/Dashboard';
 import { Summary } from './views/dashboard/Summary';
 import { useGetResponses } from './hooks/network/useResponses';
-import { Center, Loader, Stack } from '@mantine/core';
 
 export type LocationGenerics = MakeGenerics<{
   Params: {
@@ -147,19 +146,6 @@ export const routerFactory = (queryClient: any) => {
         {
           path: '/',
           element: <SurveyReports />,
-          pendingElement: async () => (
-            <Center>
-              <Stack align={'center'}>
-                <p>
-                  Surveys are being gathered, getting responses ready for you...
-                  Hold on tight!
-                </p>
-                <Loader />
-              </Stack>
-            </Center>
-          ),
-          pendingMs: 1000 * 2,
-          pendingMinMs: 500,
           loader: () =>
             queryClient.getQueryData(['linksResponses']) ??
             queryClient.fetchQuery(['linksResponses'], () => fetchLinks(true)),

--- a/admin/src/views/reports/SurveyReports.tsx
+++ b/admin/src/views/reports/SurveyReports.tsx
@@ -166,7 +166,7 @@ export const SurveyReports = (): JSX.Element => {
                   </Card.Section>
                   <Card.Section p="xl" component={Link} to={`./${link.docId}`}>
                     <Text color="dimmed" size="xs">
-                      {link?.responses} Response
+                      {link?.responses?.length} Response
                       {link?.responses?.length === 1 ? '' : 's'}
                     </Text>
                     <Divider my={'sm'} />


### PR DESCRIPTION
# Description
A bug was found where survey reports were not downloading. Investigation revealed that a previous feature (I20-172) request to improve performance caused the issue. The feature used a function ( getCountFromServer ) to count responses instead of fetching them, which resulted in the reports no longer including the actual responses. The changes were reverted, but the report page will be slower now. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
